### PR TITLE
:rocket: Add possibility to specify objectId in a quickInsert

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -75,7 +75,7 @@ function modelGraphReduxMiddleware({
     }
 
     function quickInsertRequest(action) {
-      var objectId = Date.now();
+      var objectId =  action.quickInsert.objectId || Date.now();
 
       var quickInsert = {...action.quickInsert, objectId};
       fetchRequest({
@@ -84,7 +84,7 @@ function modelGraphReduxMiddleware({
       });
       return fetchRequest({
         ...action,
-        replace: objectId,
+        [action.quickInsert.objectId ? 'update' : 'replace']: objectId,
       });
     }
 


### PR DESCRIPTION
If the `objectId` is present we do not `replace`, but `update` the concerned item in the redux store.   
It is necessary as replace will fail to update. We could also change the behaviour of replace which could perform an update if it finds in the current redux store an object with the same id.   

   
This pull request is a proposition, the implementation may not be optimal and you may want to change it.